### PR TITLE
fix: adapting for vyper>=0.4.0 with latest libs

### DIFF
--- a/moccasin.toml
+++ b/moccasin.toml
@@ -7,9 +7,7 @@ version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = [
-    "snekmate",
-]
+dependencies = ["snekmate==0.1.1rc1"]
 
 # ------------------------------------------------------------------
 #                           DEPLOYERS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,5 @@ dependencies = [
     "mamushi>=0.0.3",
     "snekmate>=0.1.0",
     "titanoboa>=0.2.4",
+    "vyper>=0.4.0",
 ]

--- a/src/decentralized_stable_coin.vy
+++ b/src/decentralized_stable_coin.vy
@@ -1,5 +1,5 @@
+# pragma version >=0.4.0
 """
-@ version 0.4.0
 @ license MIT
 @ title Decentralized Stable Coin
 @ dev Follows the ERC-20 token standard as defined at

--- a/src/dsc_engine.vy
+++ b/src/dsc_engine.vy
@@ -1,5 +1,5 @@
+# pragma version >=0.4.0
 """
-@ version 0.4.0
 @ license MIT
 @ title dsc_engine
 @ author You!

--- a/src/interfaces/AggregatorV3Interface.vyi
+++ b/src/interfaces/AggregatorV3Interface.vyi
@@ -1,5 +1,3 @@
-# pragma version ^0.4.0
-
 """
 @license MIT
 @title AggregatorV3Interface

--- a/src/interfaces/i_decentralized_stable_coin.vyi
+++ b/src/interfaces/i_decentralized_stable_coin.vyi
@@ -1,4 +1,3 @@
-# pragma version 0.4.0
 """
 @license MIT
 @title i_decentralized_stablecoin

--- a/src/mocks/MockV3Aggregator.vy
+++ b/src/mocks/MockV3Aggregator.vy
@@ -1,4 +1,4 @@
-# pragma version 0.4.0
+# pragma version >=0.4.0
 """
 @license MIT
 @title MockV3Aggregator

--- a/src/mocks/mock_more_debt_dsc.vy
+++ b/src/mocks/mock_more_debt_dsc.vy
@@ -1,5 +1,5 @@
+# pragma version >=0.4.0
 """
-@ version 0.4.0
 @ title MockMoreDebtDSC
 @ license MIT
 """

--- a/src/mocks/mock_token.vy
+++ b/src/mocks/mock_token.vy
@@ -1,4 +1,4 @@
-# pragma version 0.4.0
+# pragma version >=0.4.0
 """
 @title mock_token
 @license MIT

--- a/src/oracle_lib.vy
+++ b/src/oracle_lib.vy
@@ -1,5 +1,5 @@
+# pragma version >=0.4.0
 """
-@ version 0.4.0
 @ license MIT
 @ title oracle_lib
 @ author You!

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version < '3.13'",
@@ -230,7 +231,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -618,6 +619,7 @@ dependencies = [
     { name = "mamushi" },
     { name = "snekmate" },
     { name = "titanoboa" },
+    { name = "vyper" },
 ]
 
 [package.metadata]
@@ -625,6 +627,7 @@ requires-dist = [
     { name = "mamushi", specifier = ">=0.0.3" },
     { name = "snekmate", specifier = ">=0.1.0" },
     { name = "titanoboa", specifier = ">=0.2.4" },
+    { name = "vyper", specifier = ">=0.4.0" },
 ]
 
 [[package]]
@@ -726,8 +729,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/39/1b/d0b013bf7d1af7cf0a6a4fce13f5fe5813ab225313755367b36e714a63f8/pycryptodome-3.21.0-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:18caa8cfbc676eaaf28613637a89980ad2fd96e00c564135bf90bc3f0b34dd93", size = 2254397 },
     { url = "https://files.pythonhosted.org/packages/14/71/4cbd3870d3e926c34706f705d6793159ac49d9a213e3ababcdade5864663/pycryptodome-3.21.0-cp36-abi3-win32.whl", hash = "sha256:280b67d20e33bb63171d55b1067f61fbd932e0b1ad976b3a184303a3dad22764", size = 1775641 },
     { url = "https://files.pythonhosted.org/packages/43/1d/81d59d228381576b92ecede5cd7239762c14001a828bdba30d64896e9778/pycryptodome-3.21.0-cp36-abi3-win_amd64.whl", hash = "sha256:b7aa25fc0baa5b1d95b7633af4f5f1838467f1815442b22487426f94e0d66c53", size = 1812863 },
-    { url = "https://files.pythonhosted.org/packages/25/b3/09ff7072e6d96c9939c24cf51d3c389d7c345bf675420355c22402f71b68/pycryptodome-3.21.0-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:2cb635b67011bc147c257e61ce864879ffe6d03342dc74b6045059dfbdedafca", size = 1691593 },
-    { url = "https://files.pythonhosted.org/packages/a8/91/38e43628148f68ba9b68dedbc323cf409e537fd11264031961fd7c744034/pycryptodome-3.21.0-pp27-pypy_73-win32.whl", hash = "sha256:4c26a2f0dc15f81ea3afa3b0c87b87e501f235d332b7f27e2225ecb80c0b1cdd", size = 1765997 },
 ]
 
 [[package]]


### PR DESCRIPTION
This is a version where the project can compile with ``vyper==0.4.1`` and ``boa==0.2.6``.

By not adapting we go through the VVM that breaks the "smart" path of mox. This is not stable fix, since it might be better to check on mox side.
This pull request includes updates to dependencies and pragma version specifications in various files. The most important changes include updating the `snekmate` dependency version, adding a new dependency, and modifying pragma version directives in multiple Vyper files.

Dependency updates:

* [`moccasin.toml`](diffhunk://#diff-15ff9c987ec68177c49cb3853ee222bf1e52596a37b4f9741994b9bc4de7ee80L10-R10): Updated `snekmate` dependency to version `0.1.1rc1`.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R11): Added `vyper` dependency with version `>=0.4.0`.

Pragma version updates:

* [`src/decentralized_stable_coin.vy`](diffhunk://#diff-a2fc51d11c8d9f891a6a8159dee96c0a4d8b89b0d8a84bb5cb4d0fc6245dfef3R1-L2): Added pragma version directive `>=0.4.0`.
* [`src/dsc_engine.vy`](diffhunk://#diff-9558ee8ab7b14769430a255e88002ac8eeac9e9dd840a59a50ecbdce021b62f7R1-L2): Added pragma version directive `>=0.4.0`.
* Various files (`src/interfaces/AggregatorV3Interface.vyi`, `src/interfaces/i_decentralized_stable_coin.vyi`, `src/mocks/MockV3Aggregator.vy`, `src/mocks/mock_more_debt_dsc.vy`, `src/mocks/mock_token.vy`, `src/oracle_lib.vy`): Updated pragma version directives to `>=0.4.0` where applicable. [[1]](diffhunk://#diff-db8633731f7fad5ffdcebad65817f352d040d475e2787178a7b9c928050e7a0dL1-L2) [[2]](diffhunk://#diff-de6fd50a67c5b0ece1626a0511aa3a51a7cca56a370776aeaf02a81b7ab7b348L1) [[3]](diffhunk://#diff-a5924a4220e138e76290adda052031176b03ed830fdcc9b97a5ba5d5855e71b1L1-R1) [[4]](diffhunk://#diff-9d20d1e5fc91d655b0425141d5e1c95b551a6c13effc6d3754902b3ce130a401R1-L2) [[5]](diffhunk://#diff-ae4ddc1d569080e7f6b2b646c865e09e05301b0605f9edefaef925f75b9d6419L1-R1) [[6]](diffhunk://#diff-eb0e3441ecad3281c1e0be2c2c9350bf643a4a14de2b3a2368a01aeef85f255fR1-L2)